### PR TITLE
Add minimum required .NET assembly references to the nuget spec

### DIFF
--- a/src/Autofac.Integration.Wcf/Autofac.Integration.Wcf.nuspec
+++ b/src/Autofac.Integration.Wcf/Autofac.Integration.Wcf.nuspec
@@ -15,5 +15,9 @@
     <dependencies>
       <dependency id="Autofac" version="[3.3.1,5.0.0)" />
     </dependencies>
+    <frameworkAssemblies>
+      <frameworkAssembly assemblyName="System.ServiceModel" />
+      <frameworkAssembly assemblyName="System.ServiceModel.Activation" />
+    </frameworkAssemblies>
   </metadata>
 </package>


### PR DESCRIPTION
Update the NuGet spec to automatically include the .NET Framework assembly references required in order to use the factories.

This gets rid of the error below, for people who prefer to start from an empty class library (with no reference to System.ServiceModel and/or System.ServiceModel.Activation):

![System.ServiceModel.Activation should be referenced](http://content.screencast.com/users/caioproiete/folders/Snagit/media/714e3f06-a93a-46b7-b7d3-ea3cd8127d6e/02.10.2015-19.32.png)
