### PR TITLE
Updated version to match latest NuGet package

### DIFF
--- a/src/Autofac.Integration.Wcf/Properties/AssemblyInfo.cs
+++ b/src/Autofac.Integration.Wcf/Properties/AssemblyInfo.cs
@@ -12,6 +12,6 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCopyright("Copyright © 2014 Autofac Contributors")]
 [assembly: AssemblyDescription("Autofac Inversion of Control container WCF application integration.")]
 
-[assembly: AssemblyVersion("4.0.0.0")]
-[assembly: AssemblyFileVersion("4.0.0.0")]
+[assembly: AssemblyVersion("4.1.0.0")]
+[assembly: AssemblyFileVersion("4.1.0.0")]
 [assembly: AssemblyInformationalVersion("4.0.0.0")]


### PR DESCRIPTION
I download and compiled to debug and issue references stopped working. It turns out the assembly version of the dll in the latest NuGet package is 4.1.0.0 while the assembly version of the checked out code is 4.0.0.0. To make debugging an open source NuGet package easy, the latest assembly version in code and the latest assembly version in NuGet should match.
