### PR TITLE
Update target framework to net481

### DIFF
--- a/default.proj
+++ b/default.proj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="All" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="Current">
   <PropertyGroup>
-    <Version>7.0.0</Version>
+    <Version>8.0.0</Version>
     <SolutionName>Autofac.Wcf</SolutionName>
     <Configuration Condition="'$(Configuration)'==''">Release</Configuration>
     <ArtifactDirectory>$([System.IO.Path]::Combine($(MSBuildProjectDirectory),"artifacts"))</ArtifactDirectory>

--- a/src/Autofac.Integration.Wcf/Autofac.Integration.Wcf.csproj
+++ b/src/Autofac.Integration.Wcf/Autofac.Integration.Wcf.csproj
@@ -14,7 +14,7 @@
     <SignAssembly>true</SignAssembly>
     <NeutralLanguage>en-US</NeutralLanguage>
     <!-- Frameworks and language features -->
-    <TargetFramework>net472</TargetFramework>
+    <TargetFramework>net481</TargetFramework>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/test/Autofac.Integration.Wcf.Test/Autofac.Integration.Wcf.Test.csproj
+++ b/test/Autofac.Integration.Wcf.Test/Autofac.Integration.Wcf.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFramework>net481</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyOriginatorKeyFile>../../Autofac.snk</AssemblyOriginatorKeyFile>
@@ -40,12 +40,12 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="xunit" Version="2.6.6" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
## Summary
- Update target framework from `net472` to `net481` (.NET Framework 4.8.1)
- Bump version from 7.0.0 to 8.0.0 (breaking change: minimum framework requirement)
- Update test infrastructure: xunit 2.9.3, Microsoft.NET.Test.Sdk 18.0.0, xunit.runner.visualstudio 3.1.5

## Test plan
- [ ] CI build passes
- [ ] All tests pass on net481